### PR TITLE
Fix typo when no errors are found.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -39,7 +39,7 @@ module.exports = function () {
         }
 
         if (data.errors.length === 0) {
-            atom.workspaceView.find('.jslint .panel-body').append('<h1 class="text-success">√ No errors was found!</h1>');
+            atom.workspaceView.find('.jslint .panel-body').append('<h1 class="text-success">√ No errors were found!</h1>');
         } else {
             for (i = 0; i < data.errors.length; i += 1) {
                 error = data.errors[i];


### PR DESCRIPTION
When no errors are found by jslint, the package prints the message: "No errors was found!"

That should read: "No errors were found!"

![screen shot 2014-03-10 at 4 31 22 pm](https://f.cloud.github.com/assets/1429850/2378939/c1b5e6f2-a894-11e3-97b0-efd2c272ba3b.png)
