### PR TITLE
Fix typo when no errors are found.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -30,7 +30,7 @@ module.exports = function () {
         }
 
         if (data.errors.length === 0) {
-            msgPanel.append.header('√ No errors was found!', 'text-success');
+            msgPanel.append.header('√ No errors were found!', 'text-success');
         } else {
             for (i = 0; i < data.errors.length; i += 1) {
                 error = data.errors[i];


### PR DESCRIPTION
When no errors are found by jslint, the package prints the message: "No errors was found!"

That should read: "No errors were found!"
